### PR TITLE
GP: fix insertion error in sorted_place

### DIFF
--- a/src/gp.rs
+++ b/src/gp.rs
@@ -253,7 +253,7 @@ fn sorted_place<T>(child: (T, f64), pop: &mut Vec<(T, f64)>) {
         base + (cmp != Ordering::Greater) as usize
     };
     if idx < orig_size {
-        pop.insert(idx, child);
         pop.pop();
+        pop.insert(idx, child);
     }
 }


### PR DESCRIPTION
I changed two things about `gp::sorted_place`:
- This function previously overwrote existing items rather than inserting new items into their proper place. For example, if the `pop` was something like `[(0, 2) (0, 3) (0, 4) (0, 5) (0, 6)]` and `child` was `(0, 1)`, the result would be `[(0, 1) (0, 3) (0, 4) (0, 5) (0, 6)]` rather than `[(0, 1) (0, 2) (0, 3) (0, 4) (0, 5)]`. That means that the population no longer maintains a beam of the best items. This PR changes the behavior to insert rather than overwrite.
- Insertion order has been standardized so that `child` is always inserted *after* existing items in `pop` that have the same score as `child`.