### PR TITLE
Lexicon::combine fix

### DIFF
--- a/src/gp.rs
+++ b/src/gp.rs
@@ -258,7 +258,7 @@ fn sample_pop<T: Clone>(mut new_exprs: Vec<(T, f64)>, pop: &mut Vec<(T, f64)>) {
         .iter()
         .map(|&(_, score)| score)
         .combinations(n)
-        .map(|combo| combo.iter().sum::<f64>())
+        .map(|combo| (-combo.iter().sum::<f64>()).exp())
         .enumerate()
         .unzip();
     let idx = weighted_sample(&idxs, &scores);

--- a/src/gp.rs
+++ b/src/gp.rs
@@ -254,12 +254,15 @@ fn sample_pop<T: Clone>(mut new_exprs: Vec<(T, f64)>, pop: &mut Vec<(T, f64)>) {
     let mut options = vec![];
     options.append(pop);
     options.append(&mut new_exprs);
-    let combos: Vec<Vec<(T, f64)>> = options.into_iter().combinations(n).collect();
-    let scores: Vec<f64> = combos
+    let (idxs, scores): (Vec<usize>, Vec<f64>) = options
         .iter()
-        .map(|v| (-v.iter().map(|&(_, s)| s).sum::<f64>()).exp())
-        .collect();
-    pop.append(&mut weighted_sample(&combos, &scores).to_vec());
+        .map(|&(_, score)| score)
+        .combinations(n)
+        .map(|combo| combo.iter().sum::<f64>())
+        .enumerate()
+        .unzip();
+    let idx = weighted_sample(&idxs, &scores);
+    *pop = options.into_iter().combinations(n).nth(*idx).unwrap();
 }
 
 /// Given a mutable vector, `pop`, of item-score pairs sorted by score, insert

--- a/tests/gp.rs
+++ b/tests/gp.rs
@@ -3,7 +3,7 @@ extern crate polytype;
 extern crate programinduction;
 extern crate rand;
 use programinduction::pcfg::{self, Grammar, Rule};
-use programinduction::{GPParams, Task, GP};
+use programinduction::{GPParams, GPSelection, Task, GP};
 use rand::{rngs::SmallRng, SeedableRng};
 
 #[test]
@@ -38,6 +38,7 @@ fn gp_sum_arith() {
     };
 
     let gpparams = GPParams {
+        selection: GPSelection::Deterministic,
         population_size: 10,
         tournament_size: 5,
         mutation_prob: 0.6,


### PR DESCRIPTION
Previously, `Lexicon::combine` ignored whether the `Lexicon` was deterministic. Now, it takes that into account and makes the resulting `TRS` deterministic as needed.

