### PR TITLE
GP updates

### DIFF
--- a/src/gp.rs
+++ b/src/gp.rs
@@ -230,13 +230,17 @@ pub trait GP: Send + Sync + Sized {
         tournament_size: usize,
         population: &'a [(Self::Expression, f64)],
     ) -> &'a Self::Expression {
-        (0..population.len())
-            .choose_multiple(rng, tournament_size)
-            .into_iter()
-            .map(|i| &population[i])
-            .max_by(|&&(_, ref x), &&(_, ref y)| x.partial_cmp(y).expect("found NaN"))
-            .map(|&(ref expr, _)| expr)
-            .expect("tournament cannot select winner from no contestants")
+        if tournament_size == 1 {
+            &population[rng.gen_range(0, population.len())].0
+        } else {
+            (0..population.len())
+                .choose_multiple(rng, tournament_size)
+                .into_iter()
+                .map(|i| &population[i])
+                .max_by(|&&(_, ref x), &&(_, ref y)| x.partial_cmp(y).expect("found NaN"))
+                .map(|&(ref expr, _)| expr)
+                .expect("tournament cannot select winner from no contestants")
+        }
     }
 
     /// Initializes a population, which is a list of programs and their scores sorted by score.

--- a/src/gp.rs
+++ b/src/gp.rs
@@ -237,14 +237,14 @@ pub trait GP: Send + Sync + Sized {
         tp: &TypeSchema,
     ) -> Vec<Self::Expression>;
 
-    /// Mutate a single program.
+    /// Mutate a single program, potentially producing multiple offspring
     fn mutate<R: Rng>(
         &self,
         params: &Self::Params,
         rng: &mut R,
         prog: &Self::Expression,
         obs: &Self::Observation,
-    ) -> Self::Expression;
+    ) -> Vec<Self::Expression>;
 
     /// Perform crossover between two programs. There must be at least one child.
     fn crossover<R: Rng>(
@@ -329,7 +329,7 @@ pub trait GP: Send + Sync + Sized {
         while children.len() < gpparams.n_delta {
             let mut offspring = if rng.gen_bool(gpparams.mutation_prob) {
                 let parent = self.tournament(rng, gpparams.tournament_size, population);
-                vec![self.mutate(params, rng, parent, &task.observation)]
+                self.mutate(params, rng, parent, &task.observation)
             } else {
                 let parent1 = self.tournament(rng, gpparams.tournament_size, population);
                 let parent2 = self.tournament(rng, gpparams.tournament_size, population);

--- a/src/gp.rs
+++ b/src/gp.rs
@@ -85,6 +85,10 @@ pub struct GPParams {
     /// population.
     pub selection: GPSelection,
     pub population_size: usize,
+    // The number of individuals selected uniformly at random to participate in
+    // a tournament. If 1, a single individual is selected uniformly at random,
+    // as if the population were unweighted. This is useful for mimicking
+    // uniform weights after resampling, as in a particle filter.
     pub tournament_size: usize,
     /// Probability for a mutation. If mutation doesn't happen, the crossover will happen.
     pub mutation_prob: f64,

--- a/src/pcfg/mod.rs
+++ b/src/pcfg/mod.rs
@@ -418,6 +418,7 @@ impl Default for GeneticParams {
 impl GP for Grammar {
     type Expression = AppliedRule;
     type Params = GeneticParams;
+    type Observation = ();
 
     fn genesis<R: Rng>(
         &self,
@@ -437,6 +438,7 @@ impl GP for Grammar {
         params: &Self::Params,
         rng: &mut R,
         prog: &Self::Expression,
+        _obs: &Self::Observation,
     ) -> Self::Expression {
         let tot = params.mutation_point + params.mutation_subtree + params.mutation_reproduction;
         match Uniform::from(0f64..tot).sample(rng) {
@@ -472,6 +474,7 @@ impl GP for Grammar {
         rng: &mut R,
         parent1: &Self::Expression,
         parent2: &Self::Expression,
+        _obs: &Self::Observation,
     ) -> Vec<Self::Expression> {
         vec![
             crossover_random_node(params, parent1, parent2, rng),

--- a/src/pcfg/mod.rs
+++ b/src/pcfg/mod.rs
@@ -439,12 +439,12 @@ impl GP for Grammar {
         rng: &mut R,
         prog: &Self::Expression,
         _obs: &Self::Observation,
-    ) -> Self::Expression {
+    ) -> Vec<Self::Expression> {
         let tot = params.mutation_point + params.mutation_subtree + params.mutation_reproduction;
         match Uniform::from(0f64..tot).sample(rng) {
             // point mutation
             x if x < params.mutation_point => {
-                mutate_random_node(params, prog.clone(), rng, |ar, rng| {
+                vec![mutate_random_node(params, prog.clone(), rng, |ar, rng| {
                     let rule = &self.rules[&ar.0][ar.1];
                     let mut candidates: Vec<_> = self.rules[&ar.0]
                         .iter()
@@ -458,14 +458,16 @@ impl GP for Grammar {
                         candidates.shuffle(rng);
                         AppliedRule(ar.0, candidates[0], ar.2)
                     }
-                })
+                })]
             }
             // subtree mutation
             x if x < params.mutation_point + params.mutation_subtree => {
-                mutate_random_node(params, prog.clone(), rng, |ar, rng| self.sample(&ar.0, rng))
+                vec![mutate_random_node(params, prog.clone(), rng, |ar, rng| {
+                    self.sample(&ar.0, rng)
+                })]
             }
             // reproduction
-            _ => prog.clone(), // reproduction
+            _ => vec![prog.clone()], // reproduction
         }
     }
     fn crossover<R: Rng>(

--- a/src/trs/lexicon.rs
+++ b/src/trs/lexicon.rs
@@ -1004,6 +1004,7 @@ impl Lex {
 impl GP for Lexicon {
     type Expression = TRS;
     type Params = GeneticParams;
+    type Observation = Vec<Rule>;
     fn genesis<R: Rng>(
         &self,
         params: &Self::Params,
@@ -1051,6 +1052,7 @@ impl GP for Lexicon {
         params: &Self::Params,
         rng: &mut R,
         trs: &Self::Expression,
+        obs: &Self::Observation,
     ) -> Self::Expression {
         loop {
             if trs.is_empty() | rng.gen_bool(params.p_add) {
@@ -1071,6 +1073,7 @@ impl GP for Lexicon {
         rng: &mut R,
         parent1: &Self::Expression,
         parent2: &Self::Expression,
+        _obs: &Self::Observation,
     ) -> Vec<Self::Expression> {
         let trs = self
             .combine(rng, parent1, parent2)

--- a/src/trs/lexicon.rs
+++ b/src/trs/lexicon.rs
@@ -1052,7 +1052,7 @@ impl GP for Lexicon {
         params: &Self::Params,
         rng: &mut R,
         trs: &Self::Expression,
-        obs: &Self::Observation,
+        _obs: &Self::Observation,
     ) -> Self::Expression {
         loop {
             if trs.is_empty() | rng.gen_bool(params.p_add) {

--- a/src/trs/lexicon.rs
+++ b/src/trs/lexicon.rs
@@ -1053,17 +1053,17 @@ impl GP for Lexicon {
         rng: &mut R,
         trs: &Self::Expression,
         _obs: &Self::Observation,
-    ) -> Self::Expression {
+    ) -> Vec<Self::Expression> {
         loop {
             if trs.is_empty() | rng.gen_bool(params.p_add) {
                 let templates = self.0.read().expect("poisoned lexicon").templates.clone();
                 if let Ok(new_trs) =
                     trs.add_rule(&templates, params.atom_weights, params.max_sample_size, rng)
                 {
-                    return new_trs;
+                    return vec![new_trs];
                 }
             } else if let Ok(new_trs) = trs.delete_rule(rng) {
-                return new_trs;
+                return vec![new_trs];
             }
         }
     }

--- a/src/trs/rewrite.rs
+++ b/src/trs/rewrite.rs
@@ -335,7 +335,7 @@ impl TRS {
         let num_rules = self.len();
         let background = &self.lex.0.read().expect("poisoned lexicon").background;
         let num_background = background.len();
-        if num_background <= num_rules - 1 {
+        if num_background < num_rules - 1 {
             let i = rng.gen_range(num_background, num_rules);
             let mut j = rng.gen_range(num_background, num_rules);
             while j == i {
@@ -344,7 +344,7 @@ impl TRS {
             trs.utrs.move_rule(i, j)?;
             Ok(trs)
         } else {
-            return Err(SampleError::OptionsExhausted);
+            Err(SampleError::OptionsExhausted)
         }
     }
     /// Selects a rule from the TRS at random, finds all differences in the LHS and RHS,


### PR DESCRIPTION
A series of updates to the `GP` trait and related types:
- introduce two new `GPSelection` strategies: `Drift` and `Resample`
- let `GPSelection::update_population` handle scoring of children (so that it can manage different types of scoring strategies, including drift)
- add a shortcut for quickly running tournaments of size 1
- add associated type `GP::Observation` so that `GP::mutate` and `GP::crossover` can make use of things like type information or input/output examples

I have code making use of all these features and will open that PR as soon as this is merged.